### PR TITLE
fix: avoid symbolic links and transforma paths to canonical usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "napi",
  "napi-derive",
  "package_json_schema",
+ "rand",
  "regex",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ version-compare = "0.2"
 git-cliff-core = "2.4.0"
 chrono = "0.4.38"
 semver = "1.0.23"
+rand = "0.8.5"
 
 [build-dependencies]
 vergen = { version = "8.3.2", features = [

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -34,7 +34,10 @@ pub fn get_project_root_path(root: Option<PathBuf>) -> Option<String> {
         }
     };
 
-    Some(project_root)
+    let canonic_path = &std::fs::canonicalize(Path::new(&project_root)).unwrap();
+    let root = canonic_path.as_path().display().to_string();
+
+    Some(root)
 }
 
 /// Get the git root directory.


### PR DESCRIPTION
Paths were getting weird results because of symbolic links.
